### PR TITLE
Port Visionary-T Mini driver to ROS 2 Jazzy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(diagnostic_updater REQUIRED)
-find_package(PCL REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost 1.41 REQUIRED COMPONENTS thread system)
@@ -21,7 +20,6 @@ find_package(Boost 1.41 REQUIRED COMPONENTS thread system)
 ### BUILD ###
 include_directories(
   include
-  ${PCL_INCLUDE_DIRS}
   sick_visionary_cpp_shared
 )
 
@@ -38,8 +36,7 @@ ament_target_dependencies(sick_visionary_t_mini_node
   image_transport
   cv_bridge
   diagnostic_updater
-  OpenCV
-  PCL)
+  OpenCV)
 # link against the local shared library built in sick_visionary_cpp_shared
 target_link_libraries(sick_visionary_t_mini_node
   sick_visionary_cpp_shared
@@ -49,8 +46,6 @@ target_link_libraries(sick_visionary_t_mini_node
 )
 
 ## skip visionary_s
-
-add_definitions(${PCL_DEFINITIONS})
 
 ### INSTALL ###
 # install executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,5 +61,10 @@ install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}/launch
 )
 
+install(FILES launch/sick_visionary-t_mini.launch
+  DESTINATION share/${PROJECT_NAME}/launch
+  RENAME sick_visionary-t_mini.launch.xml
+)
+
 # ament package directive
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,16 +6,23 @@ project(sick_visionary_ros
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-# find package for header message type
-find_package(std_msgs REQUIRED)
-find_package(builtin_interfaces REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(image_transport REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(diagnostic_updater REQUIRED)
+find_package(image_transport REQUIRED)
+
+find_package(Boost REQUIRED COMPONENTS system thread)
 find_package(OpenCV REQUIRED)
-find_package(Threads REQUIRED)
-find_package(Boost 1.41 REQUIRED COMPONENTS thread system)
+
+### COMPILER FLAGS ###
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 ### BUILD ###
 include_directories(
@@ -26,40 +33,32 @@ include_directories(
 add_subdirectory(sick_visionary_cpp_shared)
 
 add_executable(sick_visionary_t_mini_node src/visionary_t_mini.cpp)
-## ignore visionary_s for ROS2 port
+# sick_visionary_s_node intentionally not built in this fork.
 
 ament_target_dependencies(sick_visionary_t_mini_node
   rclcpp
   sensor_msgs
   std_msgs
-  builtin_interfaces
-  image_transport
   cv_bridge
   diagnostic_updater
-  OpenCV)
-# link against the local shared library built in sick_visionary_cpp_shared
+  image_transport
+  OpenCV
+)
+
 target_link_libraries(sick_visionary_t_mini_node
   sick_visionary_cpp_shared
-  Threads::Threads
+  ${OpenCV_LIBS}
   Boost::thread
   Boost::system
 )
 
-## skip visionary_s
-
 ### INSTALL ###
-# install executable
 install(TARGETS sick_visionary_t_mini_node
-  RUNTIME DESTINATION lib/${PROJECT_NAME})
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
 
 install(DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}/launch
+  DESTINATION share/${PROJECT_NAME}
 )
 
-install(FILES launch/sick_visionary-t_mini.launch
-  DESTINATION share/${PROJECT_NAME}/launch
-  RENAME sick_visionary-t_mini.launch.xml
-)
-
-# ament package directive
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,78 +4,62 @@ project(sick_visionary_ros
         VERSION 1.1.2
         LANGUAGES CXX)
 
-find_package(catkin REQUIRED COMPONENTS
-  cv_bridge
-  diagnostic_updater
-  pcl_conversions
-  pcl_ros
-  image_transport
-  roscpp
-  roslaunch
-)
-
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+# find package for header message type
+find_package(std_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(diagnostic_updater REQUIRED)
+find_package(PCL REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(PCL 1.3 REQUIRED)
-
-catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS pcl_conversions pcl_ros roscpp
-)
-
-### COMPILER FLAGS ###
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_FLAGS "-Wall -Wextra")
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+find_package(Threads REQUIRED)
+find_package(Boost 1.41 REQUIRED COMPONENTS thread system)
 
 ### BUILD ###
 include_directories(
-  ${catkin_INCLUDE_DIRS}
-  ${PCL_INCLUDE_DIRS}
   include
+  ${PCL_INCLUDE_DIRS}
   sick_visionary_cpp_shared
 )
 
 add_subdirectory(sick_visionary_cpp_shared)
 
 add_executable(sick_visionary_t_mini_node src/visionary_t_mini.cpp)
-add_executable(sick_visionary_s_node src/visionary_s.cpp)
+## ignore visionary_s for ROS2 port
 
+ament_target_dependencies(sick_visionary_t_mini_node
+  rclcpp
+  sensor_msgs
+  std_msgs
+  builtin_interfaces
+  image_transport
+  cv_bridge
+  diagnostic_updater
+  OpenCV
+  PCL)
+# link against the local shared library built in sick_visionary_cpp_shared
 target_link_libraries(sick_visionary_t_mini_node
   sick_visionary_cpp_shared
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBS}
-  ${PCL_LIBRARY}
+  Threads::Threads
+  Boost::thread
+  Boost::system
 )
 
-target_link_libraries(sick_visionary_s_node
-  sick_visionary_cpp_shared
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBS}
-  ${PCL_LIBRARY}
-)
+## skip visionary_s
 
 add_definitions(${PCL_DEFINITIONS})
 
-### TEST ###
-if(CATKIN_ENABLE_TESTING)
-  roslaunch_add_file_check(launch)
-endif()
-
 ### INSTALL ###
-install(TARGETS sick_visionary_t_mini_node sick_visionary_s_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+# install executable
+install(TARGETS sick_visionary_t_mini_node
+  RUNTIME DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION share/${PROJECT_NAME}/launch
 )
+
+# ament package directive
+ament_package()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!IMPORTANT]
-> This is a work in proress branch for a ROS2 port, currently not functional.
-
 # sick_visionary_ros
 
 ## Overview

--- a/launch/sick_visionary-t_mini.launch
+++ b/launch/sick_visionary-t_mini.launch
@@ -1,8 +1,9 @@
 <!-- Entry point for using OpenNI devices -->
 <launch>
 
-  <!-- ROS2 launch format -->
-  <node pkg="sick_visionary_ros" exec="sick_visionary_t_mini_node" name="sick_visionary_t_mini" output="screen">
+  <arg name="camera" default="sick_visionary_t_mini" />
+
+  <node pkg="sick_visionary_ros" exec="sick_visionary_t_mini_node" name="$(arg camera)" output="screen">
     <!-- IP address of the Visionary-T Mini device, default: 192.168.1.10 -->
     <param name="remote_device_ip" value="192.168.1.10" />
     <param name="frame_id" value="camera" />

--- a/launch/sick_visionary-t_mini.launch
+++ b/launch/sick_visionary-t_mini.launch
@@ -1,9 +1,8 @@
 <!-- Entry point for using OpenNI devices -->
 <launch>
 
-  <arg name="camera" default="sick_visionary_t_mini" />
-
-  <node pkg="sick_visionary_ros" type="sick_visionary_t_mini_node" name="$(arg camera)" output="screen">
+  <!-- ROS2 launch format -->
+  <node pkg="sick_visionary_ros" exec="sick_visionary_t_mini_node" name="sick_visionary_t_mini" output="screen">
     <!-- IP address of the Visionary-T Mini device, default: 192.168.1.10 -->
     <param name="remote_device_ip" value="192.168.1.10" />
     <param name="frame_id" value="camera" />

--- a/launch/sick_visionary_t_mini.launch.py
+++ b/launch/sick_visionary_t_mini.launch.py
@@ -1,0 +1,39 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    args = [
+        DeclareLaunchArgument("remote_device_ip", default_value="192.168.1.10"),
+        DeclareLaunchArgument("frame_id", default_value="camera"),
+        DeclareLaunchArgument("enable_depth", default_value="true"),
+        DeclareLaunchArgument("enable_intensity", default_value="true"),
+        DeclareLaunchArgument("enable_statemap", default_value="true"),
+        DeclareLaunchArgument("enable_points", default_value="true"),
+        DeclareLaunchArgument("desired_frequency", default_value="15.0"),
+        DeclareLaunchArgument("namespace", default_value=""),
+        DeclareLaunchArgument("node_name", default_value="sick_visionary_t_mini"),
+    ]
+
+    node = Node(
+        package="sick_visionary_ros",
+        executable="sick_visionary_t_mini_node",
+        name=LaunchConfiguration("node_name"),
+        namespace=LaunchConfiguration("namespace"),
+        output="screen",
+        parameters=[
+            {
+                "remote_device_ip": LaunchConfiguration("remote_device_ip"),
+                "frame_id": LaunchConfiguration("frame_id"),
+                "enable_depth": LaunchConfiguration("enable_depth"),
+                "enable_intensity": LaunchConfiguration("enable_intensity"),
+                "enable_statemap": LaunchConfiguration("enable_statemap"),
+                "enable_points": LaunchConfiguration("enable_points"),
+                "desired_frequency": LaunchConfiguration("desired_frequency"),
+            }
+        ],
+    )
+
+    return LaunchDescription(args + [node])

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   <depend>image_transport</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_updater</depend>
-  <depend>pcl</depend>
   <depend>libopencv-dev</depend>
   <export>
     <build_type>ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,8 @@
   <depend>cv_bridge</depend>
   <depend>diagnostic_updater</depend>
   <depend>libopencv-dev</depend>
+  <depend>libboost-thread-dev</depend>
+  <depend>libboost-system-dev</depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/package.xml
+++ b/package.xml
@@ -2,22 +2,33 @@
 <package format="3">
   <name>sick_visionary_ros</name>
   <version>1.1.2</version>
-  <description>Open source drivers for the SICK Visionary-T Mini 3D-ToF camera.</description>
+  <description>Open source drivers for the SICK Visionary-S 3D camera and Visionary-T Mini 3D-ToF camera.</description>
   <license>Unlicense</license>
   <maintainer email="techsupport3dsnapshot@sick.de">SICK AG TechSupport 3D Snapshot</maintainer>
   <author email="techsupport3dsnapshot@sick.de">SICK AG TechSupport 3D Snapshot</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>builtin_interfaces</depend>
-  <depend>image_transport</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pcl_ros</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_updater</depend>
-  <depend>libopencv-dev</depend>
+  <depend>image_transport</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
   <depend>libboost-thread-dev</depend>
   <depend>libboost-system-dev</depend>
   <export>
     <build_type>ament_cmake</build_type>
+    <rosindex>
+      <tags>
+        <tag>SICK</tag>
+        <tag>Visionary-S</tag>
+        <tag>Visionary-T Mini</tag>
+        <tag>3D snapshot</tag>
+        <tag>3D vision</tag>
+        <tag>stereo</tag>
+        <tag>time-of-flight</tag>
+      </tags>
+    </rosindex>
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,32 +1,22 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>sick_visionary_ros</name>
   <version>1.1.2</version>
-  <description>Open source drivers for the SICK Visionary-S 3D camera and Visionary-T Mini 3D-ToF camera.</description>
+  <description>Open source drivers for the SICK Visionary-T Mini 3D-ToF camera.</description>
   <license>Unlicense</license>
   <maintainer email="techsupport3dsnapshot@sick.de">SICK AG TechSupport 3D Snapshot</maintainer>
   <author email="techsupport3dsnapshot@sick.de">SICK AG TechSupport 3D Snapshot</author>
-  <buildtool_depend>catkin</buildtool_depend>
-  <depend>libpcl-all-dev</depend>
-  <depend>pcl_conversions</depend>
-  <depend>pcl_ros</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>image_transport</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_updater</depend>
-  <depend>image_transport</depend>
-  <depend>roscpp</depend>
-  <depend>roslaunch</depend>
-  <depend>sensor_msgs</depend>
+  <depend>pcl</depend>
+  <depend>libopencv-dev</depend>
   <export>
-    <rosindex>
-      <tags>
-        <tag>SICK</tag>
-        <tag>Visionary-S</tag>
-        <tag>Visionary-T Mini</tag>
-        <tag>3D snapshot</tag>
-        <tag>3D vision</tag>
-        <tag>stereo</tag>
-        <tag>time-of-flight</tag>
-      </tags>
-    </rosindex>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/visionary_t_mini.cpp
+++ b/src/visionary_t_mini.cpp
@@ -206,55 +206,27 @@ void publish_frame(VisionaryTMiniData& dataHandler)
   header.stamp    = gNode->now();
   header.frame_id = gFrameId;
 
-  if (gPubCameraInfo->get_subscription_count() > 0)
-  {
-    publishedAnything = true;
-    publishCameraInfo(header, dataHandler);
-    // gPubCameraInfo_freq->tick(header.stamp);
-  }
-  if (gEnableDepth && gPubDepth.getNumSubscribers() > 0)
-  {
-    publishedAnything = true;
+  // publish all enabled streams unconditionally
+  publishCameraInfo(header, dataHandler);
+  if (gEnableDepth)
     publishDepth(header, dataHandler);
-    // gPubDepth_freq->tick(header.stamp);
-  }
-  if (gEnableIntensity && gPubIntensity.getNumSubscribers() > 0)
-  {
-    publishedAnything = true;
+  if (gEnableIntensity)
     publishIntensity(header, dataHandler);
-    // gPubIntensity_freq->tick(header.stamp);
-  }
-  if (gEnableStatemap && gPubStatemap.getNumSubscribers() > 0)
-  {
-    publishedAnything = true;
+  if (gEnableStatemap)
     publishStateMap(header, dataHandler);
-    // gPubStatemap_freq->tick(header.stamp);
-  }
-  if (gEnablePoints && gPubPoints->get_subscription_count() > 0)
-  {
-    publishedAnything = true;
+  if (gEnablePoints)
     publishPointCloud(header, dataHandler);
-    // gPubPoints_freq->tick(header.stamp);
-  }
 
-  if (publishedAnything)
-  {
-    gPubCameraInfo_freq->tick(header.stamp);
-    if (gEnableDepth)
-      gPubDepth_freq->tick(header.stamp);
-    if (gEnableIntensity)
-      gPubIntensity_freq->tick(header.stamp);
-    if (gEnableStatemap)
-      gPubStatemap_freq->tick(header.stamp);
-    if (gEnablePoints)
-      gPubPoints_freq->tick(header.stamp);
-  }
-  else
-  {
-    RCLCPP_DEBUG(gNode->get_logger(), "Nothing published");
-    if (gControl)
-      gControl->stopAcquisition();
-  }
+  // tick diagnostics
+  gPubCameraInfo_freq->tick(header.stamp);
+  if (gEnableDepth)
+    gPubDepth_freq->tick(header.stamp);
+  if (gEnableIntensity)
+    gPubIntensity_freq->tick(header.stamp);
+  if (gEnableStatemap)
+    gPubStatemap_freq->tick(header.stamp);
+  if (gEnablePoints)
+    gPubPoints_freq->tick(header.stamp);
 }
 
 void thr_publish_frame()
@@ -332,12 +304,20 @@ int main(int argc, char** argv)
     RCLCPP_ERROR(gNode->get_logger(), "Connection with devices control channel failed");
     return -1;
   }
+  // Configure the device to send blob data on the data channel
+  if (!gControl->getDataStreamConfig())
+  {
+    RCLCPP_ERROR(gNode->get_logger(), "Failed to configure data stream on device");
+    return -1;
+  }
   // To be sure the acquisition is currently stopped.
   gControl->stopAcquisition();
 
-  if (!pDataStream->open(remoteDeviceIp.c_str(), 2114u))
+  // open data channel on device's blob port
+  uint16_t dataPort = gControl->GetBlobPort();
+  if (!pDataStream->open(remoteDeviceIp.c_str(), dataPort))
   {
-    RCLCPP_ERROR(gNode->get_logger(), "Connection with devices data channel failed");
+    RCLCPP_ERROR(gNode->get_logger(), "Failed to open data channel on port %u", dataPort);
     return -1;
   }
 
@@ -355,6 +335,9 @@ int main(int argc, char** argv)
     gPubIntensity = it.advertise("intensity", 10);
   if (gEnableStatemap)
     gPubStatemap = it.advertise("statemap", 10);
+
+  // for T-Mini, perform single-step acquisitions via timer; do not call continuous startAcquisition
+  RCLCPP_INFO(gNode->get_logger(), "Using step-based acquisition for Visionary-T Mini");
 
   gDeviceIdent = gControl->getDeviceIdent();
 
@@ -400,6 +383,13 @@ int main(int argc, char** argv)
 
   // diagnostic updater with ROS2 timer
   auto diag_timer = gNode->create_wall_timer(std::chrono::seconds(1), [=]() { updater->force_update(); });
+  // Periodically trigger next frame on T-Mini (step acquisition) since continuous mode may not auto-stream
+  auto step_timer = gNode->create_wall_timer(std::chrono::milliseconds(static_cast<int>(1000.0 / desiredFreq)), [=]() {
+    if (gControl)
+    {
+      gControl->stepAcquisition();
+    }
+  });
 
   // start receiver thread for camera images
   std::thread rec_thr(boost::bind(&thr_receive_frame, pDataStream, pDataHandler));

--- a/src/visionary_t_mini.cpp
+++ b/src/visionary_t_mini.cpp
@@ -5,17 +5,17 @@
 
 #include <boost/thread.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
-#include <ros/ros.h>
-#include <sensor_msgs/CameraInfo.h>
-#include <sensor_msgs/LaserScan.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <sensor_msgs/image_encodings.h>
-#include <std_msgs/ByteMultiArray.h>
+#include <image_transport/image_transport.hpp>
+// ROS2 includes
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/header.hpp>
 #include <memory>
 
-#include <diagnostic_updater/diagnostic_updater.h>
-#include <diagnostic_updater/publisher.h>
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_updater/publisher.hpp>
 
 #include "VisionaryControl.h"
 #include "VisionaryDataStream.h"
@@ -23,12 +23,15 @@
 
 using namespace visionary;
 
+// ROS2 global node and publishers
+static std::shared_ptr<rclcpp::Node>                                     gNode;
+static image_transport::Publisher                                        gPubDepth, gPubIntensity, gPubStatemap;
+static std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::CameraInfo>>  gPubCameraInfo;
+static std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> gPubPoints;
+
 std::shared_ptr<VisionaryControl> gControl;
 
 std::shared_ptr<VisionaryTMiniData> gDataHandler;
-
-image_transport::Publisher gPubDepth, gPubIntensity, gPubStatemap;
-ros::Publisher             gPubCameraInfo, gPubPoints;
 
 std::shared_ptr<diagnostic_updater::Updater>         updater;
 std::shared_ptr<diagnostic_updater::TopicDiagnostic> gPubDepth_freq, gPubIntensity_freq, gPubStatemap_freq;
@@ -43,20 +46,21 @@ bool         gReceive = true;
 
 int gNumSubs = 0;
 
-void diag_timer_cb(const ros::TimerEvent&)
-{
-  updater->update();
-}
+// no longer used
+// void diag_timer_cb(const ros::TimerEvent&)
+// {
+//   updater->update();
+// }
 
 void driver_diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat)
 {
-  stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "driver running");
+  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "driver running");
   stat.add("frame_id", gFrameId);
   stat.add("device_ident", gDeviceIdent);
-  stat.add("NumSubscribers_CameraInfo", gPubCameraInfo.getNumSubscribers());
+  stat.add("NumSubscribers_CameraInfo", gPubCameraInfo->get_subscription_count());
   stat.add("gEnablePoints", gEnablePoints);
   if (gEnablePoints)
-    stat.add("NumSubscribers_Points", gPubPoints.getNumSubscribers());
+    stat.add("NumSubscribers_Points", gPubPoints->get_subscription_count());
   stat.add("gEnableDepth", gEnableDepth);
   if (gEnableDepth)
     stat.add("NumSubscribers_Depth", gPubDepth.getNumSubscribers());
@@ -68,86 +72,86 @@ void driver_diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat)
     stat.add("NumSubscribers_Statemap", gPubStatemap.getNumSubscribers());
 }
 
-void publishCameraInfo(std_msgs::Header header, VisionaryTMiniData& dataHandler)
+void publishCameraInfo(std_msgs::msg::Header header, VisionaryTMiniData& dataHandler)
 {
-  sensor_msgs::CameraInfo ci;
+  sensor_msgs::msg::CameraInfo ci;
   ci.header = header;
 
   ci.height = dataHandler.getHeight();
   ci.width  = dataHandler.getWidth();
 
-  ci.D.clear();
-  ci.D.resize(5, 0);
-  ci.D[0] = dataHandler.getCameraParameters().k1;
-  ci.D[1] = dataHandler.getCameraParameters().k2;
-  ci.D[2] = dataHandler.getCameraParameters().p1;
-  ci.D[3] = dataHandler.getCameraParameters().p2;
-  ci.D[4] = dataHandler.getCameraParameters().k3;
+  ci.d.clear();
+  ci.d.resize(5, 0);
+  ci.d[0] = dataHandler.getCameraParameters().k1;
+  ci.d[1] = dataHandler.getCameraParameters().k2;
+  ci.d[2] = dataHandler.getCameraParameters().p1;
+  ci.d[3] = dataHandler.getCameraParameters().p2;
+  ci.d[4] = dataHandler.getCameraParameters().k3;
 
   for (int i = 0; i < 9; i++)
   {
-    ci.K[i] = 0;
+    ci.k[i] = 0;
   }
-  ci.K[0] = dataHandler.getCameraParameters().fx;
-  ci.K[4] = dataHandler.getCameraParameters().fy;
-  ci.K[2] = dataHandler.getCameraParameters().cx;
-  ci.K[5] = dataHandler.getCameraParameters().cy;
-  ci.K[8] = 1;
+  ci.k[0] = dataHandler.getCameraParameters().fx;
+  ci.k[4] = dataHandler.getCameraParameters().fy;
+  ci.k[2] = dataHandler.getCameraParameters().cx;
+  ci.k[5] = dataHandler.getCameraParameters().cy;
+  ci.k[8] = 1;
 
   for (int i = 0; i < 12; i++)
-    ci.P[i] = 0; // data.getCameraParameters().cam2worldMatrix[i];
+    ci.p[i] = 0; // data.getCameraParameters().cam2worldMatrix[i];
   // TODO:....
-  ci.P[0]  = dataHandler.getCameraParameters().fx;
-  ci.P[5]  = dataHandler.getCameraParameters().fy;
-  ci.P[10] = 1;
-  ci.P[2]  = dataHandler.getCameraParameters().cx;
-  ci.P[6]  = dataHandler.getCameraParameters().cy;
+  ci.p[0]  = dataHandler.getCameraParameters().fx;
+  ci.p[5]  = dataHandler.getCameraParameters().fy;
+  ci.p[10] = 1;
+  ci.p[2]  = dataHandler.getCameraParameters().cx;
+  ci.p[6]  = dataHandler.getCameraParameters().cy;
 
-  gPubCameraInfo.publish(ci);
+  gPubCameraInfo->publish(ci);
 }
 
-void publishDepth(std_msgs::Header header, VisionaryTMiniData& dataHandler)
+void publishDepth(std_msgs::msg::Header header, VisionaryTMiniData& dataHandler)
 {
   std::vector<uint16_t> vec = dataHandler.getDistanceMap();
   cv::Mat               m   = cv::Mat(dataHandler.getHeight(), dataHandler.getWidth(), CV_16UC1);
   memcpy(m.data, vec.data(), vec.size() * sizeof(uint16_t));
-  sensor_msgs::ImagePtr msg =
-    cv_bridge::CvImage(std_msgs::Header(), sensor_msgs::image_encodings::TYPE_16UC1, m).toImageMsg();
+  sensor_msgs::msg::Image::SharedPtr msg =
+    cv_bridge::CvImage(std_msgs::msg::Header(), sensor_msgs::image_encodings::TYPE_16UC1, m).toImageMsg();
 
   msg->header = header;
   gPubDepth.publish(msg);
 }
 
-void publishIntensity(std_msgs::Header header, VisionaryTMiniData& dataHandler)
+void publishIntensity(std_msgs::msg::Header header, VisionaryTMiniData& dataHandler)
 {
   std::vector<uint16_t> vec = dataHandler.getIntensityMap();
   cv::Mat               m   = cv::Mat(dataHandler.getHeight(), dataHandler.getWidth(), CV_16UC1);
   memcpy(m.data, vec.data(), vec.size() * sizeof(uint16_t));
-  sensor_msgs::ImagePtr msg =
-    cv_bridge::CvImage(std_msgs::Header(), sensor_msgs::image_encodings::TYPE_16UC1, m).toImageMsg();
+  sensor_msgs::msg::Image::SharedPtr msg =
+    cv_bridge::CvImage(std_msgs::msg::Header(), sensor_msgs::image_encodings::TYPE_16UC1, m).toImageMsg();
 
   msg->header = header;
   gPubIntensity.publish(msg);
 }
 
-void publishStateMap(std_msgs::Header header, VisionaryTMiniData& dataHandler)
+void publishStateMap(std_msgs::msg::Header header, VisionaryTMiniData& dataHandler)
 {
   std::vector<uint16_t> vec = dataHandler.getStateMap();
   cv::Mat               m   = cv::Mat(dataHandler.getHeight(), dataHandler.getWidth(), CV_16UC1);
   memcpy(m.data, vec.data(), vec.size() * sizeof(uint16_t));
-  sensor_msgs::ImagePtr msg =
-    cv_bridge::CvImage(std_msgs::Header(), sensor_msgs::image_encodings::TYPE_16UC1, m).toImageMsg();
+  sensor_msgs::msg::Image::SharedPtr msg =
+    cv_bridge::CvImage(std_msgs::msg::Header(), sensor_msgs::image_encodings::TYPE_16UC1, m).toImageMsg();
 
   msg->header = header;
   gPubStatemap.publish(msg);
 }
 
-void publishPointCloud(std_msgs::Header header, VisionaryTMiniData& dataHandler)
+void publishPointCloud(std_msgs::msg::Header header, VisionaryTMiniData& dataHandler)
 {
-  typedef sensor_msgs::PointCloud2 PointCloud;
+  typedef sensor_msgs::msg::PointCloud2 PointCloud;
 
   // Allocate new point cloud message
-  PointCloud::Ptr cloudMsg(new PointCloud);
+  PointCloud::SharedPtr cloudMsg(new PointCloud);
   cloudMsg->header       = header;
   cloudMsg->height       = dataHandler.getHeight();
   cloudMsg->width        = dataHandler.getWidth();
@@ -163,12 +167,12 @@ void publishPointCloud(std_msgs::Header header, VisionaryTMiniData& dataHandler)
   for (size_t d = 0; d < 3; ++d, offset += sizeof(float))
   {
     cloudMsg->fields[d].offset   = offset;
-    cloudMsg->fields[d].datatype = int(sensor_msgs::PointField::FLOAT32);
+    cloudMsg->fields[d].datatype = int(sensor_msgs::msg::PointField::FLOAT32);
     cloudMsg->fields[d].count    = 1;
   }
 
   cloudMsg->fields[3].offset   = offset;
-  cloudMsg->fields[3].datatype = int(sensor_msgs::PointField::UINT16);
+  cloudMsg->fields[3].datatype = int(sensor_msgs::msg::PointField::UINT16);
   cloudMsg->fields[3].count    = 1;
   offset += sizeof(uint16_t);
 
@@ -191,18 +195,18 @@ void publishPointCloud(std_msgs::Header header, VisionaryTMiniData& dataHandler)
     memcpy(&cloudMsg->data[index * cloudMsg->point_step + cloudMsg->fields[0].offset], &*itPC, sizeof(PointXYZ));
     memcpy(&cloudMsg->data[index * cloudMsg->point_step + cloudMsg->fields[3].offset], &*itIntens, sizeof(uint16_t));
   }
-  gPubPoints.publish(cloudMsg);
+  gPubPoints->publish(*cloudMsg);
 }
 
 void publish_frame(VisionaryTMiniData& dataHandler)
 {
   bool publishedAnything = false;
 
-  std_msgs::Header header;
-  header.stamp    = ros::Time::now();
+  std_msgs::msg::Header header;
+  header.stamp    = gNode->now();
   header.frame_id = gFrameId;
 
-  if (gPubCameraInfo.getNumSubscribers() > 0)
+  if (gPubCameraInfo->get_subscription_count() > 0)
   {
     publishedAnything = true;
     publishCameraInfo(header, dataHandler);
@@ -226,7 +230,7 @@ void publish_frame(VisionaryTMiniData& dataHandler)
     publishStateMap(header, dataHandler);
     // gPubStatemap_freq->tick(header.stamp);
   }
-  if (gEnablePoints && gPubPoints.getNumSubscribers() > 0)
+  if (gEnablePoints && gPubPoints->get_subscription_count() > 0)
   {
     publishedAnything = true;
     publishPointCloud(header, dataHandler);
@@ -247,7 +251,7 @@ void publish_frame(VisionaryTMiniData& dataHandler)
   }
   else
   {
-    ROS_DEBUG("Nothing published");
+    RCLCPP_DEBUG(gNode->get_logger(), "Nothing published");
     if (gControl)
       gControl->stopAcquisition();
   }
@@ -276,14 +280,14 @@ void thr_receive_frame(std::shared_ptr<VisionaryDataStream> pDataStream,
       boost::thread thr(&thr_publish_frame);
     }
     else
-      ROS_INFO("skipping frame with number %d", pDataHandler->getFrameNum());
+      RCLCPP_INFO(gNode->get_logger(), "skipping frame with number %d", pDataHandler->getFrameNum());
   }
 }
 
 void _on_new_subscriber()
 {
   gNumSubs++;
-  ROS_DEBUG_STREAM("Got new subscriber, total amount of subscribers: " << gNumSubs);
+  RCLCPP_DEBUG(gNode->get_logger(), "Got new subscriber, total amount of subscribers: %d", gNumSubs);
   if (gControl)
     gControl->startAcquisition();
 }
@@ -291,53 +295,41 @@ void _on_new_subscriber()
 void _on_subscriber_disconnected()
 {
   gNumSubs--;
-  ROS_DEBUG_STREAM("Subscriber disconnected, total amount of subscribers: " << gNumSubs);
-}
-
-void on_new_subscriber_ros(const ros::SingleSubscriberPublisher&)
-{
-  _on_new_subscriber();
-}
-
-void on_new_subscriber_it(const image_transport::SingleSubscriberPublisher&)
-{
-  _on_new_subscriber();
-}
-
-void on_subscriber_disconnected_ros(const ros::SingleSubscriberPublisher&)
-{
-  _on_subscriber_disconnected();
-}
-
-void on_subscriber_disconnected_it(const image_transport::SingleSubscriberPublisher&)
-{
-  _on_subscriber_disconnected();
+  RCLCPP_DEBUG(gNode->get_logger(), "Subscriber disconnected, total amount of subscribers: %d", gNumSubs);
 }
 
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "sick_visionary_t_mini");
-  ros::NodeHandle nh("~");
+  rclcpp::init(argc, argv);
+  gNode = std::make_shared<rclcpp::Node>("sick_visionary_t_mini");
 
   // default parameters
   std::string remoteDeviceIp = "192.168.1.10";
   gFrameId                   = "camera";
 
-  ros::param::get("~remote_device_ip", remoteDeviceIp);
-  ros::param::get("~frame_id", gFrameId);
-  ros::param::get("~enable_depth", gEnableDepth);
-  ros::param::get("~enable_intensity", gEnableIntensity);
-  ros::param::get("~enable_statemap", gEnableStatemap);
-  ros::param::get("~enable_points", gEnablePoints);
+  // declare and get parameters
+  gNode->declare_parameter<std::string>("remote_device_ip", "192.168.1.10");
+  gNode->declare_parameter<std::string>("frame_id", "camera");
+  gNode->declare_parameter<bool>("enable_depth", true);
+  gNode->declare_parameter<bool>("enable_intensity", true);
+  gNode->declare_parameter<bool>("enable_statemap", true);
+  gNode->declare_parameter<bool>("enable_points", true);
+  gNode->declare_parameter<double>("desired_frequency", 15.0);
+  gNode->get_parameter("remote_device_ip", remoteDeviceIp);
+  gNode->get_parameter("frame_id", gFrameId);
+  gNode->get_parameter("enable_depth", gEnableDepth);
+  gNode->get_parameter("enable_intensity", gEnableIntensity);
+  gNode->get_parameter("enable_statemap", gEnableStatemap);
+  gNode->get_parameter("enable_points", gEnablePoints);
 
   std::shared_ptr<VisionaryTMiniData>  pDataHandler = std::make_shared<VisionaryTMiniData>();
   std::shared_ptr<VisionaryDataStream> pDataStream  = std::make_shared<VisionaryDataStream>(pDataHandler);
   gControl                                          = std::make_shared<VisionaryControl>();
 
-  ROS_INFO("Connecting to device at %s", remoteDeviceIp.c_str());
+  RCLCPP_INFO(gNode->get_logger(), "Connecting to device at %s", remoteDeviceIp.c_str());
   if (!gControl->open(VisionaryControl::ProtocolType::COLA_2, remoteDeviceIp.c_str(), 5000 /*ms*/))
   {
-    ROS_ERROR("Connection with devices control channel failed");
+    RCLCPP_ERROR(gNode->get_logger(), "Connection with devices control channel failed");
     return -1;
   }
   // To be sure the acquisition is currently stopped.
@@ -345,49 +337,34 @@ int main(int argc, char** argv)
 
   if (!pDataStream->open(remoteDeviceIp.c_str(), 2114u))
   {
-    ROS_ERROR("Connection with devices data channel failed");
+    RCLCPP_ERROR(gNode->get_logger(), "Connection with devices data channel failed");
     return -1;
   }
 
   // TODO: add get device name and device version and print to ros info.
-  ROS_INFO("Connected with Visionary-T Mini");
+  RCLCPP_INFO(gNode->get_logger(), "Connected with Visionary-T Mini");
 
-  // make me public (after init.)
-  image_transport::ImageTransport it(nh);
-  gPubCameraInfo = nh.advertise<sensor_msgs::CameraInfo>("camera_info",
-                                                         1,
-                                                         (ros::SubscriberStatusCallback)on_new_subscriber_ros,
-                                                         (ros::SubscriberStatusCallback)on_subscriber_disconnected_ros);
+  // setup publishers
+  image_transport::ImageTransport it(gNode);
+  gPubCameraInfo = gNode->create_publisher<sensor_msgs::msg::CameraInfo>("camera_info", 10);
   if (gEnableDepth)
-    gPubDepth = it.advertise("depth",
-                             1,
-                             (image_transport::SubscriberStatusCallback)on_new_subscriber_it,
-                             (image_transport::SubscriberStatusCallback)on_subscriber_disconnected_it);
+    gPubDepth = it.advertise("depth", 10);
   if (gEnablePoints)
-    gPubPoints = nh.advertise<sensor_msgs::PointCloud2>("points",
-                                                        2,
-                                                        (ros::SubscriberStatusCallback)on_new_subscriber_ros,
-                                                        (ros::SubscriberStatusCallback)on_subscriber_disconnected_ros);
+    gPubPoints = gNode->create_publisher<sensor_msgs::msg::PointCloud2>("points", 10);
   if (gEnableIntensity)
-    gPubIntensity = it.advertise("intensity",
-                                 1,
-                                 (image_transport::SubscriberStatusCallback)on_new_subscriber_it,
-                                 (image_transport::SubscriberStatusCallback)on_subscriber_disconnected_it);
+    gPubIntensity = it.advertise("intensity", 10);
   if (gEnableStatemap)
-    gPubStatemap = it.advertise("statemap",
-                                1,
-                                (image_transport::SubscriberStatusCallback)on_new_subscriber_it,
-                                (image_transport::SubscriberStatusCallback)on_subscriber_disconnected_it);
+    gPubStatemap = it.advertise("statemap", 10);
 
   gDeviceIdent = gControl->getDeviceIdent();
 
   // diagnostics
-  updater.reset(new diagnostic_updater::Updater());
-  updater->setHardwareID(nh.getNamespace());
+  updater.reset(new diagnostic_updater::Updater(gNode));
+  updater->setHardwareID(gNode->get_name());
   updater->add("driver", driver_diagnostics);
 
   double desiredFreq; // device max freq is 30FPS
-  ros::param::get("~desired_frequency", desiredFreq);
+  gNode->get_parameter("desired_frequency", desiredFreq);
   double min_freq = desiredFreq * 0.9;
   double max_freq = desiredFreq * 1.1;
 
@@ -421,13 +398,15 @@ int main(int argc, char** argv)
                                               diagnostic_updater::FrequencyStatusParam(&min_freq, &max_freq),
                                               diagnostic_updater::TimeStampStatusParam()));
 
-  ros::Timer timer = nh.createTimer(ros::Duration(1.0), diag_timer_cb);
+  // diagnostic updater with ROS2 timer
+  auto diag_timer = gNode->create_wall_timer(std::chrono::seconds(1), [=]() { updater->force_update(); });
 
   // start receiver thread for camera images
-  boost::thread rec_thr(boost::bind(&thr_receive_frame, pDataStream, pDataHandler));
+  std::thread rec_thr(boost::bind(&thr_receive_frame, pDataStream, pDataHandler));
 
-  // wait til end of exec.
-  ros::spin();
+  // spin ROS2 node
+  rclcpp::spin(gNode);
+  rclcpp::shutdown();
 
   gReceive = false;
   rec_thr.join();
@@ -435,16 +414,6 @@ int main(int argc, char** argv)
   gControl->stopAcquisition();
   gControl->close();
   pDataStream->close();
-
-  if (gEnableDepth)
-    gPubDepth.shutdown();
-  if (gEnablePoints)
-    gPubPoints.shutdown();
-  if (gEnableIntensity)
-    gPubIntensity.shutdown();
-  if (gEnableStatemap)
-    gPubStatemap.shutdown();
-  gPubCameraInfo.shutdown();
 
   return 0;
 }

--- a/src/visionary_t_mini.cpp
+++ b/src/visionary_t_mini.cpp
@@ -4,14 +4,14 @@
 // SPDX-License-Identifier: Unlicense
 
 #include <boost/thread.hpp>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <image_transport/image_transport.hpp>
-// ROS2 includes
 #include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <std_msgs/msg/header.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+#include <std_msgs/msg/byte_multi_array.hpp>
 #include <memory>
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
@@ -23,15 +23,15 @@
 
 using namespace visionary;
 
-// ROS2 global node and publishers
-static std::shared_ptr<rclcpp::Node>                                     gNode;
-static image_transport::Publisher                                        gPubDepth, gPubIntensity, gPubStatemap;
-static std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::CameraInfo>>  gPubCameraInfo;
-static std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> gPubPoints;
+std::shared_ptr<rclcpp::Node> gNode;
 
 std::shared_ptr<VisionaryControl> gControl;
 
 std::shared_ptr<VisionaryTMiniData> gDataHandler;
+
+image_transport::Publisher                                  gPubDepth, gPubIntensity, gPubStatemap;
+rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr  gPubCameraInfo;
+rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr gPubPoints;
 
 std::shared_ptr<diagnostic_updater::Updater>         updater;
 std::shared_ptr<diagnostic_updater::TopicDiagnostic> gPubDepth_freq, gPubIntensity_freq, gPubStatemap_freq;
@@ -46,11 +46,10 @@ bool         gReceive = true;
 
 int gNumSubs = 0;
 
-// no longer used
-// void diag_timer_cb(const ros::TimerEvent&)
-// {
-//   updater->update();
-// }
+void diag_timer_cb()
+{
+  updater->force_update();
+}
 
 void driver_diagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat)
 {
@@ -206,27 +205,53 @@ void publish_frame(VisionaryTMiniData& dataHandler)
   header.stamp    = gNode->now();
   header.frame_id = gFrameId;
 
-  // publish all enabled streams unconditionally
-  publishCameraInfo(header, dataHandler);
-  if (gEnableDepth)
+  if (gPubCameraInfo->get_subscription_count() > 0)
+  {
+    publishedAnything = true;
+    publishCameraInfo(header, dataHandler);
+    // gPubCameraInfo_freq->tick(header.stamp);
+  }
+  if (gEnableDepth && gPubDepth.getNumSubscribers() > 0)
+  {
+    publishedAnything = true;
     publishDepth(header, dataHandler);
-  if (gEnableIntensity)
+    // gPubDepth_freq->tick(header.stamp);
+  }
+  if (gEnableIntensity && gPubIntensity.getNumSubscribers() > 0)
+  {
+    publishedAnything = true;
     publishIntensity(header, dataHandler);
-  if (gEnableStatemap)
+    // gPubIntensity_freq->tick(header.stamp);
+  }
+  if (gEnableStatemap && gPubStatemap.getNumSubscribers() > 0)
+  {
+    publishedAnything = true;
     publishStateMap(header, dataHandler);
-  if (gEnablePoints)
+    // gPubStatemap_freq->tick(header.stamp);
+  }
+  if (gEnablePoints && gPubPoints->get_subscription_count() > 0)
+  {
+    publishedAnything = true;
     publishPointCloud(header, dataHandler);
+    // gPubPoints_freq->tick(header.stamp);
+  }
 
-  // tick diagnostics
-  gPubCameraInfo_freq->tick(header.stamp);
-  if (gEnableDepth)
-    gPubDepth_freq->tick(header.stamp);
-  if (gEnableIntensity)
-    gPubIntensity_freq->tick(header.stamp);
-  if (gEnableStatemap)
-    gPubStatemap_freq->tick(header.stamp);
-  if (gEnablePoints)
-    gPubPoints_freq->tick(header.stamp);
+  if (publishedAnything)
+  {
+    gPubCameraInfo_freq->tick(header.stamp);
+    if (gEnableDepth)
+      gPubDepth_freq->tick(header.stamp);
+    if (gEnableIntensity)
+      gPubIntensity_freq->tick(header.stamp);
+    if (gEnableStatemap)
+      gPubStatemap_freq->tick(header.stamp);
+    if (gEnablePoints)
+      gPubPoints_freq->tick(header.stamp);
+  }
+  else
+  {
+    RCLCPP_DEBUG(gNode->get_logger(), "Nothing published");
+  }
 }
 
 void thr_publish_frame()
@@ -279,14 +304,14 @@ int main(int argc, char** argv)
   std::string remoteDeviceIp = "192.168.1.10";
   gFrameId                   = "camera";
 
-  // declare and get parameters
-  gNode->declare_parameter<std::string>("remote_device_ip", "192.168.1.10");
-  gNode->declare_parameter<std::string>("frame_id", "camera");
+  gNode->declare_parameter<std::string>("remote_device_ip", remoteDeviceIp);
+  gNode->declare_parameter<std::string>("frame_id", gFrameId);
   gNode->declare_parameter<bool>("enable_depth", true);
   gNode->declare_parameter<bool>("enable_intensity", true);
   gNode->declare_parameter<bool>("enable_statemap", true);
   gNode->declare_parameter<bool>("enable_points", true);
   gNode->declare_parameter<double>("desired_frequency", 15.0);
+
   gNode->get_parameter("remote_device_ip", remoteDeviceIp);
   gNode->get_parameter("frame_id", gFrameId);
   gNode->get_parameter("enable_depth", gEnableDepth);
@@ -304,7 +329,7 @@ int main(int argc, char** argv)
     RCLCPP_ERROR(gNode->get_logger(), "Connection with devices control channel failed");
     return -1;
   }
-  // Configure the device to send blob data on the data channel
+  // Tell the device to send blob data on the data channel.
   if (!gControl->getDataStreamConfig())
   {
     RCLCPP_ERROR(gNode->get_logger(), "Failed to configure data stream on device");
@@ -313,37 +338,32 @@ int main(int argc, char** argv)
   // To be sure the acquisition is currently stopped.
   gControl->stopAcquisition();
 
-  // open data channel on device's blob port
-  uint16_t dataPort = gControl->GetBlobPort();
-  if (!pDataStream->open(remoteDeviceIp.c_str(), dataPort))
+  if (!pDataStream->open(remoteDeviceIp.c_str(), 2114u))
   {
-    RCLCPP_ERROR(gNode->get_logger(), "Failed to open data channel on port %u", dataPort);
+    RCLCPP_ERROR(gNode->get_logger(), "Connection with devices data channel failed");
     return -1;
   }
 
   // TODO: add get device name and device version and print to ros info.
   RCLCPP_INFO(gNode->get_logger(), "Connected with Visionary-T Mini");
 
-  // setup publishers
+  // make me public (after init.)
   image_transport::ImageTransport it(gNode);
-  gPubCameraInfo = gNode->create_publisher<sensor_msgs::msg::CameraInfo>("camera_info", 10);
+  gPubCameraInfo = gNode->create_publisher<sensor_msgs::msg::CameraInfo>("camera_info", 1);
   if (gEnableDepth)
-    gPubDepth = it.advertise("depth", 10);
+    gPubDepth = it.advertise("depth", 1);
   if (gEnablePoints)
-    gPubPoints = gNode->create_publisher<sensor_msgs::msg::PointCloud2>("points", 10);
+    gPubPoints = gNode->create_publisher<sensor_msgs::msg::PointCloud2>("points", 2);
   if (gEnableIntensity)
-    gPubIntensity = it.advertise("intensity", 10);
+    gPubIntensity = it.advertise("intensity", 1);
   if (gEnableStatemap)
-    gPubStatemap = it.advertise("statemap", 10);
-
-  // for T-Mini, perform single-step acquisitions via timer; do not call continuous startAcquisition
-  RCLCPP_INFO(gNode->get_logger(), "Using step-based acquisition for Visionary-T Mini");
+    gPubStatemap = it.advertise("statemap", 1);
 
   gDeviceIdent = gControl->getDeviceIdent();
 
   // diagnostics
   updater.reset(new diagnostic_updater::Updater(gNode));
-  updater->setHardwareID(gNode->get_name());
+  updater->setHardwareID(gNode->get_namespace());
   updater->add("driver", driver_diagnostics);
 
   double desiredFreq; // device max freq is 30FPS
@@ -381,22 +401,16 @@ int main(int argc, char** argv)
                                               diagnostic_updater::FrequencyStatusParam(&min_freq, &max_freq),
                                               diagnostic_updater::TimeStampStatusParam()));
 
-  // diagnostic updater with ROS2 timer
-  auto diag_timer = gNode->create_wall_timer(std::chrono::seconds(1), [=]() { updater->force_update(); });
-  // Periodically trigger next frame on T-Mini (step acquisition) since continuous mode may not auto-stream
-  auto step_timer = gNode->create_wall_timer(std::chrono::milliseconds(static_cast<int>(1000.0 / desiredFreq)), [=]() {
-    if (gControl)
-    {
-      gControl->stepAcquisition();
-    }
-  });
+  auto timer = gNode->create_wall_timer(std::chrono::seconds(1), &diag_timer_cb);
+
+  // ROS 2 has no SubscriberStatusCallback equivalent — start streaming once.
+  gControl->startAcquisition();
 
   // start receiver thread for camera images
-  std::thread rec_thr(boost::bind(&thr_receive_frame, pDataStream, pDataHandler));
+  boost::thread rec_thr(boost::bind(&thr_receive_frame, pDataStream, pDataHandler));
 
-  // spin ROS2 node
+  // wait til end of exec.
   rclcpp::spin(gNode);
-  rclcpp::shutdown();
 
   gReceive = false;
   rec_thr.join();
@@ -404,6 +418,8 @@ int main(int argc, char** argv)
   gControl->stopAcquisition();
   gControl->close();
   pDataStream->close();
+
+  rclcpp::shutdown();
 
   return 0;
 }


### PR DESCRIPTION
Brings the Visionary-T Mini streaming-variant driver up to a working ROS 2 Jazzy state. Builds on @stffnb 's `port_to_ros2` (3 commits cherry-picked) and adds the Jazzy-specific build/runtime fixes that were missing for the driver to compile and run at the same framerate as the ROS 1 driver.

ref:
- https://github.com/4am-robotics/orga/issues/7259